### PR TITLE
Fix code block issues in add code h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ taranpreet@debian fm shell sdg24.com
 ## add code
 
 ```
+
 import frappe
 from frappe.model.document import Document
 from frappe.model.docstatus import DocStatus
@@ -184,7 +185,8 @@ class LibraryMembership(Document):
         )
         if exists:
             frappe.throw("There is an active membership for this member")
-       ```
+
+```
 
 
 
@@ -257,9 +259,9 @@ class LibraryTransaction(Document):
     	)
     	if not valid_membership:
         	frappe.throw("The member does not have a valid membership")
+
+
 ```
-
-
 
 
       


### PR DESCRIPTION
Missing backticks were added in two sections: add code, the one just below it